### PR TITLE
Add Service to preserve window size and position between launches

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const Chrome = require('./lib/components/chrome')
 const FrameDecorator = require('./lib/middleware/frame_decorator')
 const KeyListener = require('./lib/services/key_listener')
 const Menubar = require('./lib/services/menubar')
+const WindowState = require('./lib/services/window_state')
 
 start()
 
@@ -18,6 +19,7 @@ function start () {
   startTicker(store)
   KeyListener(window, store.dispatch)
   Menubar(window, store.dispatch)
+  WindowDimensions(window, store.dispatch)
 
   // Initialize store
   store.dispatch(actions.loadConfig())

--- a/lib/services/window_dimensions.js
+++ b/lib/services/window_dimensions.js
@@ -1,0 +1,65 @@
+function WindowDimensions (win, dispatch) {
+  const nwWin = nw.Window.get()
+
+  try {
+    const savedDimensions = getDimensions()
+    if (savedDimensions) {
+      applyDimensions(savedDimensions, nwWin)
+    }
+  } catch (e) {
+    console.error(e)
+    resetDimensions()
+  }
+
+  let resizeTimeout
+  nwWin.window.addEventListener('resize', function () {
+    clearTimeout(resizeTimeout)
+    resizeTimeout = setTimeout(() => {
+      saveDimensions(nwWin)
+    }, 500)
+  }, false)
+}
+
+function applyDimensions (dimensions, nwWin) {
+  nw.Screen.Init()
+
+  const windowIsOnScreen = nw.Screen.screens.find((screen) => {
+    const { x, y, width, height } = screen.bounds
+    const insideX = dimensions.x > x && dimensions.x < x + width
+    const insideY = dimensions.y > y && dimensions.y < y + height
+
+    if (insideX && insideY) {
+      return true
+    }
+  })
+
+  if (windowIsOnScreen) {
+    console.log('applying dimensions: ' + JSON.stringify(dimensions))
+    nwWin.window.moveTo(dimensions.x, dimensions.y)
+    nwWin.window.resizeTo(dimensions.width, dimensions.height)
+  } else {
+    nwWin.setPosition("center")
+  }
+}
+
+function dimensionsOf (nwWin) {
+  const { x, y, width, height } = nwWin
+  return { x, y, width, height }
+}
+
+function saveDimensions (nwWin) {
+  const dimensionsJSON = JSON.stringify(dimensionsOf(nwWin))
+  console.log('saving dimensions: ' + dimensionsJSON)
+  return localStorage.windowDimensions = dimensionsJSON
+}
+
+function getDimensions () {
+  return JSON.parse(localStorage.windowDimensions || 'null')
+}
+
+function resetDimensions () {
+  console.log('resetting dimensions')
+  return localStorage.windowDimensions = 'null'
+}
+
+module.exports = WindowDimensions


### PR DESCRIPTION
Every time the window is resized its dimensions and position is saved to `localStorage`. On launch it is restored to last saved size.

This is completely oblivious to `redux` or the rest of the app for that matter. I tried to keep it as simple as possible.

Thank you for Halla!
